### PR TITLE
data_access_byte_ wrong size

### DIFF
--- a/shruthi/part.cc
+++ b/shruthi/part.cc
@@ -30,6 +30,7 @@
 #include "shruthi/midi_dispatcher.h"
 #include "shruthi/parameter.h"
 #include "shruthi/storage.h"
+#include "shruthi/parameter.h"
 
 using namespace avrlib;
 
@@ -39,7 +40,7 @@ namespace shruthi {
 Part part;
 
 /* <static> */
-uint8_t Part::data_access_byte_[1];
+uint8_t Part::data_access_byte_[kNumParameters+1];
 Patch Part::patch_;
 SequencerSettings Part::sequencer_settings_;
 SystemSettings Part::system_settings_;


### PR DESCRIPTION
I've been compiling this code with avrstudio, and running it, the display has been showing 128 for all the variables. 

After much time debugging I have established that the storage data_access_byte_ is only set to one element! So any writes and reads were out of bounds.

Is kNumParameters the right ? I added 1 as you seem to do that to the index in the code.
